### PR TITLE
Fix configuration values in restore-module script

### DIFF
--- a/imageroot/actions/restore-module/50traefik
+++ b/imageroot/actions/restore-module/50traefik
@@ -14,8 +14,8 @@ request = json.load(sys.stdin)
 renv = request['environment']
 
 configure_retval = agent.tasks.run(agent_id=os.environ['AGENT_ID'], action='configure-module', data={
-    "lets_encrypt": renv["TRAEFIK_LETS_ENCRYPT"],
-    "host": renv["TRAEFIK_HOST"],
-    "http2https": renv["TRAEFIK_HTTP2HTTPS"],
+    "lets_encrypt": renv["TRAEFIK_LETS_ENCRYPT"] == "True",
+    "host": renv["TRAEFIK_HOST"] ,
+    "http2https": renv["TRAEFIK_HTTP2HTTPS"] == "True",
 })
 agent.assert_exp(configure_retval['exit_code'] == 0, "The configure-module subtask failed!")


### PR DESCRIPTION
This pull request fixes the configuration values in the restore-module script. Specifically, it ensures that the "lets_encrypt" and "http2https" values are correctly converted to boolean values before being passed to the "configure-module" action. This fix resolves an issue where the script was not working as expected.