### PR TITLE
Add password tooltip to host input in Settings.vue

### DIFF
--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -36,7 +36,8 @@
     "tcp_port_pgsql_tcp_port_tips": "TCP port restricted to the node localhost",
     "domain_already_used_in_traefik": "Domain already used in traefik",
     "host_pattern": "Must be a valid fully qualified domain name",
-    "host_format": "Must be a valid fully qualified domain name"
+    "host_format": "Must be a valid fully qualified domain name",
+    "password_tips":"Default login and password are 'admin@nethserver.org' and 'Nethesis,1234', change them as soon as possible"
   },
   "about": {
     "title": "About"

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -23,7 +23,7 @@
       <cv-column>
         <cv-tile light>
           <cv-form @submit.prevent="configureModule">
-            <cv-text-input
+            <NsTextInput
               :label="$t('settings.pgadmin_fqdn')"
               placeholder="postgresql.example.org"
               v-model.trim="host"
@@ -31,8 +31,13 @@
               :invalid-message="$t(error.host)"
               :disabled="loading.getConfiguration || loading.configureModule"
               ref="host"
+              tooltipAlignment="center"
+              tooltipDirection="right"
             >
-            </cv-text-input>
+            <template slot="tooltip">
+              <div v-html="$t('settings.password_tips')"></div>
+            </template>
+            </NsTextInput>
             <cv-toggle
               value="letsEncrypt"
               :label="$t('settings.lets_encrypt')"


### PR DESCRIPTION
This pull request adds a password tooltip to the host input in the Settings.vue file. The tooltip provides information about the default login and password, which are 'admin@nethserver.org' and 'Nethesis,1234'. Users are advised to change the default login and password as soon as possible.