### PR TITLE
Open postgres to listen on the network and enforce protection with a random password

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ on the root terminal
   
     `runagent -m postgresql1`
 
- the path become :
+ the path becomes:
 ```
     echo $PATH
     /home/postgresql1/.config/bin:/usr/local/agent/pyenv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/usr/

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ psql -h IP_of_Node -U postgres -d postgres -p ${TCP_PORT_PGSQL}
 
 The password of postgres user can be found inside a secret file `/home/postgresql1/.config/state/secrets/passwords.env`
 
-`${TCP_PORT_PGSQL} `is set inside the environment of the module
+`${TCP_PORT_PGSQL} `is set inside the environment of the module ans visible in the settings page > advanced menu
 
 `IP_of_Node` is the IP running the container, it must be the internal wiregard IP for example 10.5.4.1, the port is not opened in the firewall
 
@@ -117,6 +117,7 @@ on the root terminal
     `runagent -m postgresql1`
 
  the path becomes:
+
 ```
     echo $PATH
     /home/postgresql1/.config/bin:/usr/local/agent/pyenv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/usr/
@@ -127,9 +128,9 @@ on the root terminal
  ```
 podman ps
 CONTAINER ID  IMAGE                                      COMMAND               CREATED        STATUS        PORTS                    NAMES
-d292c6ff28e9  localhost/podman-pause:4.6.1-1702418000                          9 minutes ago  Up 9 minutes  127.0.0.1:20015->80/tcp  80b8de25945f-infra
-d8df02bf6f4a  docker.io/library/mariadb:10.11.5          --character-set-s...  9 minutes ago  Up 9 minutes  127.0.0.1:20015->80/tcp  mariadb-app
-9e58e5bd676f  docker.io/library/nginx:stable-alpine3.17  nginx -g daemon o...  9 minutes ago  Up 9 minutes  127.0.0.1:20015->80/tcp  postgresql-app
+e44540b6e758  localhost/podman-pause:4.9.4-rhel-1714526144              6 minutes ago  Up 6 minutes  127.0.0.1:20025->80/tcp, 0.0.0.0:20024->5432/tcp  a3b7a6c1ec0a-infra
+e78d65411183  docker.io/library/postgres:14.12-bookworm     postgres    6 minutes ago  Up 6 minutes  127.0.0.1:20025->80/tcp, 0.0.0.0:20024->5432/tcp  postgresql-app
+6a642dc061e4  docker.io/dpage/pgadmin4:8.6                              6 minutes ago  Up 6 minutes  127.0.0.1:20025->80/tcp, 0.0.0.0:20024->5432/tcp  pgadmin-app
 ```
 
 you can see what environment variable is inside the container

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ pgadmin needs a default credential to login: `admin@nethserver.org` `Nethesis,12
 psql -h IP_of_Node -U postgres -d postgres -p ${TCP_PORT_PGSQL}
 ```
 
-The password of postgres user can be found inside a secret file `/home/postgresql1/.config/state/secrets/passwords.secret`
+The password of postgres user can be found inside a secret file `/home/postgresql1/.config/state/secrets/passwords.env`
 
 `${TCP_PORT_PGSQL} `is set inside the environment of the module
 

--- a/README.md
+++ b/README.md
@@ -58,15 +58,18 @@ pgadmin needs a default credential to login: `admin@nethserver.org` `Nethesis,12
     runagent -m postgresql1
     podman exec -ti postgresql-app psql -U postgres
 
-2. using another terminal, access the database from the host using the postgres uri
+
+2 - access inside the cluster via the network
 
 ```
-psql postgresql://postgres:Nethesis,1234@IP_of_Node:${TCP_PORT_PGSQL}/postgres
+psql -h IP_of_Node -U postgres -d postgres -p ${TCP_PORT_PGSQL}
 ```
+
+The password of postgres user can be found inside a secret file `/home/postgresql1/.config/state/secrets/passwords.secret`
 
 `${TCP_PORT_PGSQL} `is set inside the environment of the module
 
-`IP_of_Node` is the IP running the container, it might be the internal wiregard IP or the external IP of the node
+`IP_of_Node` is the IP running the container, it must be the internal wiregard IP for example 10.5.4.1, the port is not opened in the firewall
 
 ## Get the configuration
 You can retrieve the configuration with
@@ -113,7 +116,7 @@ on the root terminal
   
     `runagent -m postgresql1`
 
- the path become : 
+ the path become :
 ```
     echo $PATH
     /home/postgresql1/.config/bin:/usr/local/agent/pyenv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/usr/
@@ -132,19 +135,33 @@ d8df02bf6f4a  docker.io/library/mariadb:10.11.5          --character-set-s...  9
 you can see what environment variable is inside the container
 ```
 podman exec  postgresql-app env
-PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-TERM=xterm
-PKG_RELEASE=1
-MARIADB_DB_HOST=127.0.0.1
-MARIADB_DB_NAME=postgresql
-MARIADB_IMAGE=docker.io/mariadb:10.11.5
-MARIADB_DB_TYPE=mysql
+PG_MAJOR=14
+POSTGRES_USER=postgres
+TCP_PORT_PGSQL=20040
 container=podman
-NGINX_VERSION=1.24.0
-NJS_VERSION=0.7.12
-MARIADB_DB_USER=postgresql
-MARIADB_DB_PASSWORD=postgresql
-MARIADB_DB_PORT=3306
+PGADMIN4_IMAGE=docker.io/dpage/pgadmin4:8.6
+TRAEFIK_HOST=p3.rocky9-3.org
+TCP_PORT_PGADMIN=20041
+IMAGE_REOPODIGEST=ghcr.io/nethserver/postgresql@sha256:7214285985f1b83a24349b734e492b39d32627a818a71a71e53ad2f611602904
+IMAGE_DIGEST=sha256:7214285985f1b83a24349b734e492b39d32627a818a71a71e53ad2f611602904
+PGDATA=/var/lib/postgresql/data
+TCP_PORTS_RANGE=20040-20041
+GOSU_VERSION=1.17
+TRAEFIK_HTTP2HTTPS=False
+IMAGE_ID=0697feb0d5ae91dd8aeecfd4ec3cc686ed2a24e8b02a875715898dddfe17ab28
+TCP_PORTS=20040,20041
+LANG=en_US.utf8
+MODULE_ID=postgresql3
+NODE_ID=1
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/postgresql/14/bin
+IMAGE_URL=ghcr.io/nethserver/postgresql:opennetwork
+TRAEFIK_LETS_ENCRYPT=False
+MODULE_UUID=631248ae-6296-45c9-84d7-a981fb269dc1
+TCP_PORT=20040
+POSTGRES_PASSWORD=d4079c78337e27abd9b200458a46834dbf205218
+POSTGRES_IMAGE=docker.io/postgres:14.12-bookworm
+PG_VERSION=14.12-1.pgdg120+1
+TERM=xterm
 HOME=/root
 ```
 

--- a/imageroot/actions/create-module/20create-secrets
+++ b/imageroot/actions/create-module/20create-secrets
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+../bin/create-secrets

--- a/imageroot/bin/create-secrets
+++ b/imageroot/bin/create-secrets
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+set -e
+
+# restict to 400
+umask 266
+
+if [[ ! -d ~/.config/state/secrets ]]; then
+    /usr/bin/mkdir -p ~/.config/state/secrets
+fi
+
+if [[ ! -f ~/.config/state/secrets/passwords.secret ]]; then
+    password_postgres=$(/usr/bin/openssl rand -hex 20)
+    /usr/bin/echo "POSTGRES_PASSWORD=$password_postgres" > ~/.config/state/secrets/passwords.secret
+fi

--- a/imageroot/bin/create-secrets
+++ b/imageroot/bin/create-secrets
@@ -16,7 +16,7 @@ fi
 # restict to 400
 umask 266
 
-if [[ ! -f ~/.config/state/secrets/passwords.secret ]]; then
+if [[ ! -f ~/.config/state/secrets/passwords.env ]]; then
     password_postgres=$(/usr/bin/openssl rand -hex 20)
-    /usr/bin/echo "POSTGRES_PASSWORD=$password_postgres" > ~/.config/state/secrets/passwords.secret
+    /usr/bin/echo "POSTGRES_PASSWORD=$password_postgres" > ~/.config/state/secrets/passwords.env
 fi

--- a/imageroot/bin/create-secrets
+++ b/imageroot/bin/create-secrets
@@ -7,12 +7,14 @@
 
 set -e
 
-# restict to 400
-umask 266
+
 
 if [[ ! -d ~/.config/state/secrets ]]; then
     /usr/bin/mkdir -p ~/.config/state/secrets
 fi
+
+# restict to 400
+umask 266
 
 if [[ ! -f ~/.config/state/secrets/passwords.secret ]]; then
     password_postgres=$(/usr/bin/openssl rand -hex 20)

--- a/imageroot/etc/state-include.conf
+++ b/imageroot/etc/state-include.conf
@@ -5,3 +5,4 @@
 # List here what you want to save during backup : volumes or file Path
 state/postgresql.pg_dump
 volumes/pgadmin-data
+state/secrets/passwords.env

--- a/imageroot/state/config_server.json
+++ b/imageroot/state/config_server.json
@@ -5,9 +5,9 @@
             "Group": "Localhost server",
             "Port": 5432,
             "Username": "postgres",
-            "Host": "127.0.0.1",
+            "Host": "/var/run/postgresql/",
             "MaintenanceDB": "postgres",
-            "PassFile": "/pgpassfile"
+            "PassFile": ""
         }
     }
 }

--- a/imageroot/state/pgpassfile
+++ b/imageroot/state/pgpassfile
@@ -1,1 +1,0 @@
-127.0.0.1:5432:postgres:postgres:Nethesis,1234

--- a/imageroot/systemd/user/pgadmin-app.service
+++ b/imageroot/systemd/user/pgadmin-app.service
@@ -11,6 +11,7 @@ After=postgresql.service pgadmin-app.service
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
 EnvironmentFile=%S/state/environment
+EnvironmentFile=%S/state/secrets/passwords.secret
 EnvironmentFile=-%S/state/smarthost.env
 WorkingDirectory=%S/state
 Restart=always
@@ -30,7 +31,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/pgadmin-app.pid \
     --env 'PGADMIN_CONFIG_UPGRADE_CHECK_ENABLED=False' \
     --env 'PGADMIN_CONFIG_LOGIN_BANNER="Authorised users only!"' \
     --env 'PGADMIN_CONFIG_CONSOLE_LOG_LEVEL=40' \
-    --env 'PGADMIN_CONFIG_CONFIG_DATABASE_URI="postgresql://postgres:Nethesis,1234@127.0.0.1:5432/postgres"' \
+    --env 'PGADMIN_CONFIG_CONFIG_DATABASE_URI="postgresql://postgres:${POSTGRES_PASSWORD}@127.0.0.1:5432/postgres"' \
     --env-file=%S/state/smarthost.env \
     ${PGADMIN4_IMAGE}
 ExecStartPost=/usr/bin/bash -c "while ! podman exec pgadmin-app /venv/bin/python3 setup.py get-users ;  do sleep 5 ; done"

--- a/imageroot/systemd/user/pgadmin-app.service
+++ b/imageroot/systemd/user/pgadmin-app.service
@@ -11,7 +11,6 @@ After=postgresql.service pgadmin-app.service
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
 EnvironmentFile=%S/state/environment
-EnvironmentFile=%S/state/secrets/passwords.secret
 EnvironmentFile=-%S/state/smarthost.env
 WorkingDirectory=%S/state
 Restart=always

--- a/imageroot/systemd/user/pgadmin-app.service
+++ b/imageroot/systemd/user/pgadmin-app.service
@@ -24,14 +24,13 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/pgadmin-app.pid \
     --pod-id-file %t/postgresql.pod-id --replace -d --name  pgadmin-app \
     --volume pgadmin-data:/var/lib/pgadmin:Z \
     --volume ./config_server.json:/pgadmin4/config_server.json:Z \
-    --volume ./pgpassfile:/pgadmin4/pgpassfile:Z \
+    --volume socket:/var/run/postgresql:z \
     --env 'PGADMIN_DEFAULT_EMAIL=admin@nethserver.org' \
     --env 'PGADMIN_DEFAULT_PASSWORD=Nethesis,1234' \
     --env 'PGADMIN_CONFIG_ENHANCED_COOKIE_PROTECTION=True' \
     --env 'PGADMIN_CONFIG_UPGRADE_CHECK_ENABLED=False' \
     --env 'PGADMIN_CONFIG_LOGIN_BANNER="Authorised users only!"' \
     --env 'PGADMIN_CONFIG_CONSOLE_LOG_LEVEL=40' \
-    --env 'PGADMIN_CONFIG_CONFIG_DATABASE_URI="postgresql://postgres:${POSTGRES_PASSWORD}@127.0.0.1:5432/postgres"' \
     --env-file=%S/state/smarthost.env \
     ${PGADMIN4_IMAGE}
 ExecStartPost=/usr/bin/bash -c "while ! podman exec pgadmin-app /venv/bin/python3 setup.py get-users ;  do sleep 5 ; done"

--- a/imageroot/systemd/user/postgresql-app.service
+++ b/imageroot/systemd/user/postgresql-app.service
@@ -11,7 +11,7 @@ After=postgresql.service
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
 EnvironmentFile=%S/state/environment
-EnvironmentFile=%S/state/secrets/passwords.secret
+EnvironmentFile=%S/state/secrets/passwords.env
 Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/postgresql-app.pid %t/postgresql-app.ctr-id

--- a/imageroot/systemd/user/postgresql-app.service
+++ b/imageroot/systemd/user/postgresql-app.service
@@ -20,6 +20,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/postgresql-app.pid \
     --pod-id-file %t/postgresql.pod-id --replace -d --name postgresql-app \
     --env-file=%S/state/environment \
     --volume pgdata:/var/lib/postgresql/data:Z \
+    --volume socket:/var/run/postgresql:z \
     --env POSTGRES_USER=postgres \
     --env POSTGRES_PASSWORD=${POSTGRES_PASSWORD} \
     ${POSTGRES_IMAGE}

--- a/imageroot/systemd/user/postgresql-app.service
+++ b/imageroot/systemd/user/postgresql-app.service
@@ -11,6 +11,7 @@ After=postgresql.service
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
 EnvironmentFile=%S/state/environment
+EnvironmentFile=%S/state/secrets/passwords.secret
 Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/postgresql-app.pid %t/postgresql-app.ctr-id
@@ -20,7 +21,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/postgresql-app.pid \
     --env-file=%S/state/environment \
     --volume pgdata:/var/lib/postgresql/data:Z \
     --env POSTGRES_USER=postgres \
-    --env POSTGRES_PASSWORD=Nethesis,1234 \
+    --env POSTGRES_PASSWORD=${POSTGRES_PASSWORD} \
     ${POSTGRES_IMAGE}
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/postgresql-app.ctr-id -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/postgresql-app.ctr-id

--- a/imageroot/systemd/user/postgresql.service
+++ b/imageroot/systemd/user/postgresql.service
@@ -23,7 +23,7 @@ ExecStartPre=/usr/bin/podman pod create --infra-conmon-pidfile %t/postgresql.pid
     --pod-id-file %t/postgresql.pod-id \
     --name postgresql \
     --publish 127.0.0.1:${TCP_PORT_PGADMIN}:80 \
-    --publish 127.0.0.1:${TCP_PORT_PGSQL}:5432 \
+    --publish ${TCP_PORT_PGSQL}:5432 \
     --replace
 ExecStart=/usr/bin/podman pod start --pod-id-file %t/postgresql.pod-id
 ExecStop=/usr/bin/podman pod stop --ignore --pod-id-file %t/postgresql.pod-id -t 10

--- a/imageroot/update-module.d/10upgrade-to-private-secrets
+++ b/imageroot/update-module.d/10upgrade-to-private-secrets
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+# If the control reaches this step, the service can be enabled and started
+
+set -e
+
+# Redirect any output to the journal (stderr)
+exec 1>&2
+
+# we want to migrate from 1.0.5 when the postgres password was default and no secrets were created
+
+if [[ ! -f ~/.config/state/secrets/passwords.secret ]]; then
+    ../bin/create-secrets
+    source ~/.config/state/secrets/passwords.secret
+    # change the password of the postgres user
+    podman exec -ti postgresql-app sh -c "PGPASSWORD=${POSTGRES_PASSWORD} psql -U postgres -d postgres -c \"ALTER USER postgres WITH PASSWORD '${POSTGRES_PASSWORD}';\""
+fi

--- a/imageroot/update-module.d/10upgrade-to-private-secrets
+++ b/imageroot/update-module.d/10upgrade-to-private-secrets
@@ -14,9 +14,9 @@ exec 1>&2
 
 # we want to migrate from 1.0.5 when the postgres password was default and no secrets were created
 
-if [[ ! -f ~/.config/state/secrets/passwords.secret ]]; then
+if [[ ! -f ~/.config/state/secrets/passwords.env ]]; then
     ../bin/create-secrets
-    source ~/.config/state/secrets/passwords.secret
+    source ~/.config/state/secrets/passwords.env
     # change the password of the postgres user
     podman exec -ti postgresql-app sh -c "PGPASSWORD=${POSTGRES_PASSWORD} psql -U postgres -d postgres -c \"ALTER USER postgres WITH PASSWORD '${POSTGRES_PASSWORD}';\""
 fi


### PR DESCRIPTION
These changes improve security by avoiding the use of hardcoded passwords in the service configuration files and allow to open the network tcp port inside the trusted zone

This pull request includes changes to the `postgresql-app.service` and `pgadmin-app.service` files to update them to use secrets for the database password. It also adds a new script, `create-secrets`, for module initialization. The `create-secrets` script generates a random password for the PostgreSQL user and stores it in a secrets file.

pgadmin connects to the databse on a unix socket
