### PR TITLE
Update build-images.sh to use pgadmin4:8.8

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -45,7 +45,7 @@ buildah config --entrypoint=/ \
     --label="org.nethserver.authorizations=traefik@node:routeadm" \
     --label="org.nethserver.tcp-ports-demand=2" \
     --label="org.nethserver.rootfull=0" \
-    --label="org.nethserver.images=docker.io/dpage/pgadmin4:8.6 docker.io/postgres:14.12-bookworm" \
+    --label="org.nethserver.images=docker.io/dpage/pgadmin4:8.8 docker.io/postgres:14.12-bookworm" \
     "${container}"
 # Commit the image
 buildah commit "${container}" "${repobase}/${reponame}"


### PR DESCRIPTION
This pull request updates the `build-images.sh` script to use `pgadmin4:8.8` instead of `pgadmin4:8.6`. This ensures that the latest version of `pgadmin4` is used in the build process.

https://github.com/NethServer/dev