### PR TITLE
Refactor password tooltip and update ns8-ui-lib

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@carbon/icons-vue": "^10.37.0",
     "@carbon/vue": "^2.40.0",
-    "@nethserver/ns8-ui-lib": "^0.1.22",
+    "@nethserver/ns8-ui-lib": "^1.1.4",
     "await-to-js": "^3.0.0",
     "axios": "^0.21.2",
     "carbon-components": "^10.41.0",

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -34,9 +34,9 @@
               tooltipAlignment="center"
               tooltipDirection="right"
             >
-            <template slot="tooltip">
-              <div v-html="$t('settings.password_tips')"></div>
-            </template>
+              <template slot="tooltip">
+                <div>{{ $t("settings.password_tips") }}</div>
+              </template>
             </NsTextInput>
             <cv-toggle
               value="letsEncrypt"

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1012,10 +1012,10 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
-"@nethserver/ns8-ui-lib@^0.1.22":
-  version "0.1.25"
-  resolved "https://registry.npmjs.org/@nethserver/ns8-ui-lib/-/ns8-ui-lib-0.1.25.tgz"
-  integrity sha512-jSYcG/PDd356Dvdb7BZkMBC+h9fxHvROWTrPsXRplCV4GsTcygO8Uc3H/ch3eo51Rre4qqrk/AP7j5Tzz3tBzQ==
+"@nethserver/ns8-ui-lib@^1.1.4":
+  version "1.1.4"
+  resolved "https://registry.npmmirror.com/@nethserver/ns8-ui-lib/-/ns8-ui-lib-1.1.4.tgz#6e8a47356c43773527c2d410e907c3dbe41326e2"
+  integrity sha512-z5lpixFPFlhBejMIYOFG6+YS74wcoppg1bat3WM1HTVo5gmpE3GVMOOIz+A2ThO9S/4ecWs6LG/GT/syQI2k5A==
   dependencies:
     "@rollup/plugin-json" "^4.1.0"
     core-js "^3.15.2"


### PR DESCRIPTION
Refactored the password tooltip in Settings.vue to use the Vue template syntax instead of v-html. Also, updated the @nethserver/ns8-ui-lib dependency to version 1.1.4 in the package.json and yarn.lock files.

Refs:
- https://github.com/NethServer/dev/issues/7090